### PR TITLE
Work around installation problem on systems with Windows 8.1 Update 1 already installed

### DIFF
--- a/setup/Download8.nsh
+++ b/setup/Download8.nsh
@@ -14,7 +14,6 @@
 Function NeedsWin81Update1
 	Call NeedsKB2919355
 	Call NeedsKB2932046
-	Call NeedsKB2959977
 	Call NeedsKB2937592
 	Call NeedsKB2934018
 	Pop $0
@@ -27,7 +26,6 @@ Function NeedsWin81Update1
 	${OrIf} $1 == 1
 	${OrIf} $2 == 1
 	${OrIf} $3 == 1
-	${OrIf} $4 == 1
 		Push 1
 	${Else}
 		Push 0

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -538,7 +538,6 @@ Function .onInit
 		Pop $0
 		${If} $0 == 0
 			!insertmacro RemoveSection ${WIN81UPDATE1}
-			!insertmacro RemoveSection ${WIN81WUA}
 		${EndIf}
 
 		Call NeedsKB3021910


### PR DESCRIPTION
Work around installation problem on systems with Windows 8.1 Update 1 already installed.

This fixes two bugs:

1 - Windows 8.1 Update 1 systems, especially those which use
  slipstreamed media from Microsoft's websites, are not able to receive
  KB2959977 due to the fact that they come with an update which
  supersedes that one. To work around this, remove the update check for
  that patch so that it doesn't trigger Windows 8.1 Update 1
  installation on systems which already have it, but leave it so that it
  will install on systems which do need Windows 8.1 Update 1 to be
  installed.

2 - On systems where Windows 8.1 Update 1 is already installed, a minor
  bug in setup.nsi resulted in it not getting the Servicing Stack
  Update.

Tested on both original media (no Update 1 installed), and slipstreamed media from Microsoft's website.

Fixes #104 and #135