### PR TITLE
Force logging off at the end of the RunOnce process

### DIFF
--- a/setup/Constants.nsh
+++ b/setup/Constants.nsh
@@ -48,7 +48,7 @@
 
 ; Win32 constants
 !define EWX_REBOOT       0x02
-!define EWX_FORCEIFHUNG  0x10
+!define EWX_FORCE        0x04
 
 !define TDCBF_YES_BUTTON 0x2
 !define TDCBF_NO_BUTTON  0x4

--- a/setup/RunOnce.nsh
+++ b/setup/RunOnce.nsh
@@ -148,7 +148,7 @@ Function CleanUpRunOnce
 			${EndIf}
 
 			RMDir /r /REBOOTOK "$PROFILE"
-			System::Call "user32::ExitWindowsEx(i ${EWX_FORCEIFHUNG}, i 0) i .r0"
+			System::Call "user32::ExitWindowsEx(i ${EWX_FORCE} , i 0) i .r0"
 		${EndIf}
 	${EndIf}
 FunctionEnd


### PR DESCRIPTION
Currently we are using EWX_FORCEIFHUNG, which seems to have problems. In an attempt to fix this, I tried sleeping for 5 minutes, and EWX_FORCEIFHUNG didn't take effect.

Since we're on a temporary user anyway, forcing a logoff should be safe.

Note that after this is done and the system is rebooted, only ntuser.ini is left in the C:\Documents and Settings\LegacyUpdateTemp directory.

Fixes #113