### PR TITLE
Allow opting into Microsoft Update on Windows 7.

### DIFF
--- a/setup/EnableMicrosoftUpdate.nsh
+++ b/setup/EnableMicrosoftUpdate.nsh
@@ -1,0 +1,6 @@
+Function EnableMicrosoftUpdate
+	File EnableMicrosoftUpdate.vbs
+	!insertmacro DetailPrint "Enabling Microsoft Update..."
+	; Call upon EnableMicrosoftUpdate.vbs to do our job here...
+	ExecWait `$SYSDIR\WScript.exe EnableMicrosoftUpdate.vbs /b /nologo`
+FunctionEnd

--- a/setup/EnableMicrosoftUpdate.vbs
+++ b/setup/EnableMicrosoftUpdate.vbs
@@ -1,0 +1,12 @@
+' This script enables opting into Microsoft Update on Windows 7.
+
+' First, we need to create a service manager object.
+Set ServiceManager = CreateObject("Microsoft.Update.ServiceManager")
+
+' Next, we need to define a Client Application ID.
+ServiceManager.ClientApplicationID = "Legacy Update" ' Could be anything
+
+' Finally, add the Microsoft Update Service GUID
+Set NewUpdateService = ServiceManager.AddService2("7971f918-a847-4430-9279-4a52d1efe18d", 7, "")
+
+' The Windows Update service now needs to be restarted to acquire the new service registration.

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -63,6 +63,7 @@ VIFileVersion    ${LONGVERSION}
 !include DownloadWUA.nsh
 !include RunOnce.nsh
 !include UpdateRoots.nsh
+!include EnableMicrosoftUpdate.nsh
 
 !insertmacro GetParameters
 !insertmacro GetOptions
@@ -223,6 +224,11 @@ ${MementoSectionEnd}
 ${MementoSection} "Update root certificates store" ROOTCERTS
 	Call ConfigureCrypto
 	Call UpdateRoots
+${MementoSectionEnd}
+
+${MementoSection} "Enable Microsoft Update" MSUPDATE
+	Call EnableMicrosoftUpdate
+	!insertmacro RestartWUAUService
 ${MementoSectionEnd}
 
 ; Main installation
@@ -411,6 +417,7 @@ SectionEnd
 	!insertmacro MUI_DESCRIPTION_TEXT ${ROOTCERTS}    "Updates the root certificate store to the latest from Microsoft, and enables additional modern security features. Root certificates are used to verify the security of encrypted (https) connections. This fixes connection issues with some websites."
 	!insertmacro MUI_DESCRIPTION_TEXT ${LEGACYUPDATE} "Installs Legacy Update, enabling access to the full Windows Update interface via the legacyupdate.net website on Windows 2000/XP, and Windows Update Control Panel on Windows Vista. Windows Update will be configured to use the Legacy Update proxy server."
 	!insertmacro MUI_DESCRIPTION_TEXT ${ACTIVATE}     "Your copy of Windows is not activated. If you update the root certificates store, Windows Product Activation can be completed over the internet. Legacy Update can start the activation wizard after installation so you can activate your copy of Windows."
+	!insertmacro MUI_DESCRIPTION_TEXT ${MSUPDATE}	  "Enables Microsoft Update on Windows 7, giving you access to updates for Microsoft products such as Office and Visual Studio through Windows Update."
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 Function .onInit
@@ -514,6 +521,7 @@ Function .onInit
 	${Else}
 		!insertmacro RemoveSection ${WIN7SP1}
 		!insertmacro RemoveSection ${WIN7WUA}
+		!insertmacro RemoveSection ${MSUPDATE}
 	${EndIf}
 
 	${If} ${IsWin8}


### PR DESCRIPTION
In order to do this, we'll use a tweaked version of Microsoft's OptIn example VBS script, and then call upon it from within the installer.

Fixes #124 