### PR TITLE
Fix installing LegacyUpdate on Windows 8.0.

### DIFF
--- a/setup/Download8.nsh
+++ b/setup/Download8.nsh
@@ -1,5 +1,5 @@
 ; Windows 8 Servicing Stack
-!insertmacro MSUHandler "KB2937636" "Servicing Stack Update for Windows 8"   "Package_for_KB2937636_RTM" "6.2.1.4"
+!insertmacro MSUHandler "KB4598297" "Servicing Stack Update for Windows 8"   "Package_for_KB4598297" "6.2.1.8"
 
 ; Windows 8.1 Servicing Stack
 !insertmacro MSUHandler "KB3021910" "Servicing Stack Update for Windows 8.1" "Package_for_KB3021910"     "6.3.1.2"

--- a/setup/Patches.ini
+++ b/setup/Patches.ini
@@ -275,9 +275,10 @@ x86=http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/
 x64=http://download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x64_f7b1de8ea7cf8faf57b0138c4068d2e899e2b266.msu
 
 ; 8/Server 2012
-[KB2937636]
-x86=http://download.windowsupdate.com/c/msdownload/update/software/crup/2014/07/windows8-rt-kb2937636-x86_9c82bea917f34d581ab164eb08f93e2141412d7d.msu
-x64=http://download.windowsupdate.com/c/msdownload/update/software/crup/2014/07/windows8-rt-kb2937636-x64_29e0b587c8f09bcf635c1b79d09c00eef33113ec.msu
+
+[KB4598297]
+x86=http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows8-rt-kb4598297-x86_a517ea587c91af5f803b0973d40166c3e076fe5c.msu
+x64=http://download.windowsupdate.com/d/msdownload/update/software/secu/2021/01/windows8-rt-kb4598297-x64_60f5c45d1216ee6ff1ab88ca03b037ac519ad0da.msu
 
 ; 8.1/Server 2012 R2
 [KB3021910]

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -181,9 +181,10 @@ Section "Windows Servicing Stack update" WIN7WUA
 SectionEnd
 
 ; 8 prerequisities
+
 Section "Windows Servicing Stack update" WIN8WUA
 	SectionIn Ro
-	Call DownloadKB2937636
+	Call DownloadKB4598297
 	Call RebootIfRequired
 SectionEnd
 
@@ -522,7 +523,7 @@ Function .onInit
 			!insertmacro RemoveSection ${WIN81UPGRADE}
 		${EndIf}
 
-		Call NeedsKB2937636
+		Call NeedsKB4598297
 		Pop $0
 		${If} $0 == 0
 			!insertmacro RemoveSection ${WIN8WUA}


### PR DESCRIPTION
Let's do this by replacing the Windows Update Agent update with one that is newer and which has the fix for Microsoft ADV990001 (a security update for the Windows Update Agent that was never made available to 8.0 unless you knew to apply it manually). This works because Windows 8 can apply updates from Windows 8 Embedded and Windows Server 2012.

Tested with a fresh install of Windows 8 Pro retail and a complete run of Windows Update after LegacyUpdate was installed. No ill-effects were discovered.

For ADV990001, see: [MSRC ADV990001](https://msrc.microsoft.com/update-guide/vulnerability/ADV990001)

Fixes #128