### PR TITLE
 Install the proper Service Pack and WUA for Windows XP Embedded. 

### DIFF
--- a/setup/Download2KXP.nsh
+++ b/setup/Download2KXP.nsh
@@ -78,7 +78,7 @@ FunctionEnd
 !insertmacro PatchHandler "XPSP2"    "Windows XP Service Pack 2"                         "/passive /norestart"
 !insertmacro PatchHandler "XPSP3"    "Windows XP Service Pack 3"                         "/passive /norestart"
 !insertmacro PatchHandler "2003SP2"  "Windows XP x64 Edition/Server 2003 Service Pack 2" "/passive /norestart"
-!insertmacro PatchHandler_NoLang "XPESP3"   "Windows XP Embedded Service Pack 3"		 "/passive /norestart"
+!insertmacro PatchHandler_NoLang "XPESP3"   "Windows XP Embedded Service Pack 3"         "/passive /norestart"
 
 Function DownloadIE6
 	Call NeedsIE6

--- a/setup/Download2KXP.nsh
+++ b/setup/Download2KXP.nsh
@@ -47,9 +47,27 @@ FunctionEnd
 	FunctionEnd
 !macroend
 
+!macro PatchHandler_NoLang kbid title params
+	; Used because Windows XP Embedded SP3 has no other languages than English.
+	; This presents a problem because PatchHandler looks for a language specific
+	; URL inside patches.ini, and as a result will not be able to find the URL.
+	; Work around this by creating a new version of this macro with no language.
+	Function Download${kbid}
+		Call Needs${kbid}
+		Pop $0
+		${If} $0 == 1
+			Call GetArch
+			Pop $0
+			ReadINIStr $0 $PLUGINSDIR\Patches.ini "${kbid}" $0
+			!insertmacro DownloadAndInstall "${title}" "$0" "${kbid}.exe" "${params}"
+		${EndIf}
+	FunctionEnd
+!macroend
+
 !insertmacro NeedsSPHandler "W2KSP4"  "Win2000"   2
 !insertmacro NeedsSPHandler "XPSP2"   "WinXP2002" 0
 !insertmacro NeedsSPHandler "XPSP3"   "WinXP2002" 2
+!insertmacro NeedsSPHandler "XPESP3"  "WinXP2002" 2
 !insertmacro NeedsSPHandler "2003SP2" "WinXP2003" 1
 
 !insertmacro NeedsFileVersionHandler "KB835732" "kernel32.dll" "5.00.2195.6897"
@@ -60,6 +78,7 @@ FunctionEnd
 !insertmacro PatchHandler "XPSP2"    "Windows XP Service Pack 2"                         "/passive /norestart"
 !insertmacro PatchHandler "XPSP3"    "Windows XP Service Pack 3"                         "/passive /norestart"
 !insertmacro PatchHandler "2003SP2"  "Windows XP x64 Edition/Server 2003 Service Pack 2" "/passive /norestart"
+!insertmacro PatchHandler_NoLang "XPESP3"   "Windows XP Embedded Service Pack 3"		 "/passive /norestart"
 
 Function DownloadIE6
 	Call NeedsIE6

--- a/setup/DownloadWUA.nsh
+++ b/setup/DownloadWUA.nsh
@@ -5,6 +5,7 @@ Function DetermineWUAVersion
 	${If} ${IsWinXP2002}
 	${AndIf} ${AtLeastServicePack} 3
 	${AndIf} ${IsHomeEdition}
+	${OrIf} ${IsEmbedded} ; XP Embedded requires the same WUA as Home.
 		StrCpy $1 "5.1.3-home"
 	${Else}
 		GetWinVer $1 Major

--- a/setup/Patches.ini
+++ b/setup/Patches.ini
@@ -176,6 +176,10 @@ RUS-x86=http://download.windowsupdate.com/msdownload/update/software/svpk/2008/0
 SVE-x86=http://download.windowsupdate.com/msdownload/update/software/svpk/2008/04/windowsxp-kb936929-sp3-x86-sve_13c5ecca22e12224934a1faa1190ee34db3995ae.exe
 TRK-x86=http://download.windowsupdate.com/msdownload/update/software/svpk/2008/04/windowsxp-kb936929-sp3-x86-trk_5aaf60501636af08c97ef1c18f1315f4ed6fbcdf.exe
 
+[XPESP3]
+; Only seems to be available in English.
+x86=http://web.archive.org/web/20140813085714/http://download.microsoft.com/download/3/a/e/3aea3d4e-159d-4078-a5b4-5b1e4f5a4db4/WindowsXP-KB958255-ENU.exe
+
 ; Windows XP 2003
 [2003SP2]
 CHH-x86=http://download.windowsupdate.com/msdownload/update/v3-19990518/cabpool/windowsserver2003-kb914961-sp2-x86-chh_2de4fb187533e226cd615bcda30b9a8a2836e197.exe

--- a/setup/WinVer.nsh
+++ b/setup/WinVer.nsh
@@ -117,7 +117,7 @@
 !define IsServerOS         `!= _WinVer_TestProduct ${VER_NT_WORKSTATION}`
 
 !define IsHomeEdition      `"" _WinVer_TestSuite ${VER_SUITE_PERSONAL}`
-!define IsEmbedded		   `"" _WinVer_TestSuite ${VER_SUITE_EMBEDDEDNT}`
+!define IsEmbedded         `"" _WinVer_TestSuite ${VER_SUITE_EMBEDDEDNT}`
 
 !define IsSafeMode         `!= _WinVer_TestSystemMetric ${SM_CLEANBOOT}`
 

--- a/setup/WinVer.nsh
+++ b/setup/WinVer.nsh
@@ -117,6 +117,7 @@
 !define IsServerOS         `!= _WinVer_TestProduct ${VER_NT_WORKSTATION}`
 
 !define IsHomeEdition      `"" _WinVer_TestSuite ${VER_SUITE_PERSONAL}`
+!define IsEmbedded		   `"" _WinVer_TestSuite ${VER_SUITE_EMBEDDEDNT}`
 
 !define IsSafeMode         `!= _WinVer_TestSystemMetric ${SM_CLEANBOOT}`
 

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -144,6 +144,11 @@ ${MementoSection} "Windows XP Service Pack 3" XPSP3
 	Call RebootIfRequired
 ${MementoSectionEnd}
 
+${MementoSection} "Windows XP Embedded Service Pack 3" XPESP3
+	Call DownloadXPESP3
+	Call RebootIfRequired
+${MementoSectionEnd}
+
 ; XP 2003 prerequisities
 Section "Windows XP/Server 2003 Service Pack 2" 2003SP2
 	Call Download2003SP2
@@ -400,6 +405,7 @@ SectionEnd
 	!insertmacro MUI_DESCRIPTION_TEXT ${W2KSP4}       "Updates Windows 2000 to Service Pack 4, as required to install the Windows Update Agent.$\r$\n${DESCRIPTION_REBOOTS} ${DESCRIPTION_SUPEULA}"
 	!insertmacro MUI_DESCRIPTION_TEXT ${IE6SP1}       "Updates Internet Explorer to 6.0 SP1, as required for Legacy Update.$\r$\n${DESCRIPTION_REBOOTS} ${DESCRIPTION_SUPEULA}"
 	!insertmacro MUI_DESCRIPTION_TEXT ${XPSP3}        "Updates Windows XP to Service Pack 3. Required if you would like to activate Windows online. ${DESCRIPTION_REBOOTS} ${DESCRIPTION_SUPEULA}"
+	!insertmacro MUI_DESCRIPTION_TEXT ${XPESP3}       "Updates Windows XP Embedded to Service Pack 3. Required if you would like to activate Windows online. ${DESCRIPTION_REBOOTS} ${DESCRIPTION_SUPEULA}"
 	!insertmacro MUI_DESCRIPTION_TEXT ${WES09}        "Configures Windows to appear as Windows Embedded POSReady 2009 to Windows Update, enabling access to Windows XP security updates released between 2014 and 2019. Please note that Microsoft officially advises against doing this."
 	!insertmacro MUI_DESCRIPTION_TEXT ${2003SP2}      "Updates Windows XP x64 Edition or Windows Server 2003 to Service Pack 2. Required if you would like to activate Windows online. ${DESCRIPTION_REBOOTS} ${DESCRIPTION_SUPEULA}"
 	!insertmacro MUI_DESCRIPTION_TEXT ${VISTASP2}     "Updates Windows Vista or Windows Server 2008 to Service Pack 2, as required to install the Windows Update Agent. ${DESCRIPTION_REBOOTS} ${DESCRIPTION_MSLT}"
@@ -471,10 +477,26 @@ Function .onInit
 
 	${If} ${IsWinXP2002}
 		; Determine whether XP prereqs need to be installed
-		Call NeedsXPSP3
-		Pop $0
-		${If} $0 == 0
+
+		${IfNot} ${IsEmbedded}
+			; Windows XP Embedded (including FLP and WEPOS) has a different
+			; service pack
+			!insertmacro RemoveSection ${XPESP3}
+			Call NeedsXPSP3
+			Pop $0
+			${If} $0 == 0
+				!insertmacro RemoveSection ${XPSP3}
+			${EndIf}
+		${EndIf}
+
+		${If} ${IsEmbedded}
+			; For Windows XP Embedded.
 			!insertmacro RemoveSection ${XPSP3}
+			Call NeedsXPESP3
+			Pop $0
+			${If} $0 == 0
+				!insertmacro RemoveSection ${XPESP3}
+			${EndIf}
 		${EndIf}
 
 		ReadRegDword $0 HKLM "${REGPATH_POSREADY}" "Installed"
@@ -483,6 +505,7 @@ Function .onInit
 		${EndIf}
 	${Else}
 		!insertmacro RemoveSection ${XPSP3}
+		!insertmacro RemoveSection ${XPESP3}
 		!insertmacro RemoveSection ${WES09}
 	${EndIf}
 


### PR DESCRIPTION
This updates the installer to install Service Pack 3 for XP Embedded,
WEPOS, and Windows Fundamentals for Legacy PCs. The standard version of
SP3 for XP is incompatible with these variants.

Note that the version of WUA used for XP Home is required for XP
Embedded and variants.

Tested with fresh installations of WEPOS and Fundamentals for Legacy
PCs, and on POSReady 2009.

Fixes #73 