### PR TITLE
Add support for Windows Home Server 2011 by fixing WUA and bugs

### DIFF
--- a/setup/Common.nsh
+++ b/setup/Common.nsh
@@ -143,6 +143,18 @@ FunctionEnd
 	!insertmacro ExecWithErrorHandling '${name} (${kbid})' '$WINDIR\system32\wusa.exe /quiet /norestart "$0"' 1
 !macroend
 
+!macro DownloadAndInstallCAB kbid name url
+	!insertmacro DownloadIfNeeded '${name} (${kbid})' '${url}' '${kbid}.cab'
+
+	; To install a CAB file, we need to use DISM.
+	!insertmacro DetailPrint "Installing ${name} (${kbid})..."
+	; Because NSIS is running in 32-bit mode, we need to use the 'sysnative' shortcut.
+	; Without this, we'll get an Error Code 11, which means that it's trying to use
+	; a 32-bit DISM to apply updates to a 64-bit installation of Windows.
+	; On 32-bit installations, this seems to have no detrimental impact.
+	!insertmacro ExecWithErrorHandling '${name} (${kbid})' '$WINDIR\sysnative\dism.exe /Online /Add-Package /PackagePath:"$0" /Quiet /NoRestart' 1
+!macroend
+
 !macro EnsureAdminRights
 	UserInfo::GetAccountType
 	Pop $0

--- a/setup/DownloadWHS.nsh
+++ b/setup/DownloadWHS.nsh
@@ -1,0 +1,27 @@
+!macro CABHandler kbid title packagename
+	Function Needs${kbid}
+		Call GetComponentArch
+		Pop $0
+		ClearErrors
+		ReadRegStr $1 HKLM "${REGPATH_PACKAGEINDEX}\${packagename}~31bf3856ad364e35~$0~~0.0.0.0" ""
+		${If} ${Errors}
+			Push 1
+		${Else}
+			Push 0
+		${EndIf}
+	FunctionEnd
+
+	Function Download${kbid}
+		Call Needs${kbid}
+		Pop $0
+		${If} $0 == 1
+			Call GetArch
+			Pop $0
+			ReadINIStr $1 $PLUGINSDIR\Patches.ini "${kbid}" $0
+			!insertmacro DownloadAndInstallCAB "${kbid}" "${title}" "$1"
+		${EndIf}
+	FunctionEnd
+!macroend
+
+; Windows Home Server 2011 Update Rollup 4
+!insertmacro CABHandler "KB2757011" "Windows Home Server 2011 Update Rollup 4" "Package_for_KB2757011"

--- a/setup/Patches.ini
+++ b/setup/Patches.ini
@@ -323,3 +323,7 @@ x64=http://download.windowsupdate.com/c/msdownload/update/software/crup/2014/03/
 [KB2934018]
 x86=http://download.windowsupdate.com/d/msdownload/update/software/secu/2014/04/windows8.1-kb2934018-x86_8fb05387836b77abbf1755185ae743c9da417e9a.msu
 x64=http://download.windowsupdate.com/c/msdownload/update/software/secu/2014/04/windows8.1-kb2934018-x64_234a5fc4955f81541f5bfc0d447e4fc4934efc38.msu
+
+; Windows Home Server 2011
+[KB2757011]
+x64=http://download.windowsupdate.com/msdownload/update/software/uprl/2012/12/windows6.1-kb2757011-x64_d01351ef77faa57aff72b862902b847155f7da52.cab

--- a/setup/WinVer.nsh
+++ b/setup/WinVer.nsh
@@ -117,7 +117,7 @@
 !define IsServerOS         `!= _WinVer_TestProduct ${VER_NT_WORKSTATION}`
 
 !define IsHomeEdition      `"" _WinVer_TestSuite ${VER_SUITE_PERSONAL}`
-
+!define IsHomeServer       `"" _WinVer_TestSuite ${VER_SUITE_WH_SERVER}`
 !define IsSafeMode         `!= _WinVer_TestSystemMetric ${SM_CLEANBOOT}`
 
 !define IsServicePack      `=  _WinVer_TestSP`

--- a/setup/setup.nsi
+++ b/setup/setup.nsi
@@ -61,6 +61,7 @@ VIFileVersion    ${LONGVERSION}
 !include DownloadVista7.nsh
 !include Download8.nsh
 !include DownloadWUA.nsh
+!include DownloadWHS.nsh
 !include RunOnce.nsh
 !include UpdateRoots.nsh
 
@@ -166,6 +167,13 @@ Section "Windows Servicing Stack update" VISTASSU
 	Call DownloadKB4015195
 	Call DownloadKB4015380
 	Call DownloadKB4493730
+	Call RebootIfRequired
+SectionEnd
+
+; Windows Home Server prerequisites
+Section "Windows Home Server Update Rollup 4" WHS2011U4
+	SectionIn Ro
+	Call DownloadKB2757011
 	Call RebootIfRequired
 SectionEnd
 
@@ -410,6 +418,7 @@ SectionEnd
 	!insertmacro MUI_DESCRIPTION_TEXT ${WIN81UPGRADE} "Windows 8 can be updated to Windows 8.1. This process involves a manual download. After Legacy Update setup completes, a Microsoft website will be opened with more information."
 	!insertmacro MUI_DESCRIPTION_TEXT ${WIN81UPDATE1} "Updates Windows 8.1 to Update 1, as required to resolve issues with the Windows Update Agent. Also required to upgrade to Windows 10.$\r$\n${DESCRIPTION_REBOOTS}"
 	!insertmacro MUI_DESCRIPTION_TEXT ${WIN81SSU}     "Updates Windows 8.1 or Windows Server 2012 R2 with additional updates required to resolve issues with the Windows Update Agent.$\r$\n${DESCRIPTION_REBOOTS}"
+	!insertmacro MUI_DESCRIPTION_TEXT ${WHS2011U4}	  "Updates Windows Home Server 2011 to Update Rollup 4 to resolve issues with the Windows Update Agent. Also fixes data corruption problems.$\r$\n${DESCRIPTION_REBOOTS}"
 	!insertmacro MUI_DESCRIPTION_TEXT ${WUA}          "Updates the Windows Update Agent to the latest version, as required for Legacy Update."
 	!insertmacro MUI_DESCRIPTION_TEXT ${ROOTCERTS}    "Updates the root certificate store to the latest from Microsoft, and enables additional modern security features. Root certificates are used to verify the security of encrypted (https) connections. This fixes connection issues with some websites."
 	!insertmacro MUI_DESCRIPTION_TEXT ${ACTIVATE}     "Your copy of Windows is not activated. If you update the root certificates store, Windows Product Activation can be completed over the internet. Legacy Update can start the activation wizard after installation so you can activate your copy of Windows."
@@ -523,6 +532,16 @@ Function .onInit
 			!insertmacro RemoveSection ${WIN7SP1}
 		${EndIf}
 
+		${If} ${IsHomeServer}
+			Call NeedsKB2757011
+			Pop $0
+			${If} $0 == 0
+				!insertmacro RemoveSection ${WHS2011U4}
+			${EndIf}
+		${Else}
+			!insertmacro RemoveSection ${WHS2011U4}
+		${EndIf}
+
 		Call NeedsWin7SHA2
 		Pop $0
 		${If} $0 == 0
@@ -531,6 +550,7 @@ Function .onInit
 	${Else}
 		!insertmacro RemoveSection ${WIN7SP1}
 		!insertmacro RemoveSection ${WIN7SSU}
+		!insertmacro RemoveSection ${WHS2011U4}
 	${EndIf}
 
 	${If} ${IsWin8}


### PR DESCRIPTION
This installs Update Rollup 4, which resolves some problems with Windows Update failures with other WHS updates. In addition, it fixes a data corruption bug that should be resolved on fresh installations.

The PowerPack updates for WHS 2007 are still available and seem to not be required for Windows Update since the WUA issues were resolved in previous commits.

Fixes #134