### PR TITLE
Silence some warnings caused by using Visual Studio 2022.

### DIFF
--- a/LegacyUpdate/LaunchUpdateSite.cpp
+++ b/LegacyUpdate/LaunchUpdateSite.cpp
@@ -9,9 +9,6 @@
 
 #pragma comment(lib, "wininet.lib")
 
-// Ignore C4311 and C4302, which is for typecasts. It is due to ShellExec and should be safe to bypass.
-#pragma warning(disable: 4311)
-#pragma warning(disable: 4302)
 
 const LPCSTR UpdateSiteHostname     = "legacyupdate.net";
 const LPWSTR UpdateSiteURLHttp      = L"http://legacyupdate.net/windowsupdate/v6/";
@@ -92,7 +89,10 @@ void CALLBACK LaunchUpdateSite(HWND hwnd, HINSTANCE hinstance, LPSTR lpszCmdLine
 		GetOwnFileName(&filename, &filenameSize);
 		WCHAR args[MAX_PATH + 20];
 		StringCchPrintfW(args, filenameSize + 20, L"\"%ls\",LaunchUpdateSite", filename);
+		// Ignore C4311 and C4302, which is for typecasts. It is due to ShellExec and should be safe to bypass.
+		#pragma warning(disable: 4311 4302)
 		int execResult = (int)ShellExecute(NULL, L"runas", L"rundll32.exe", args, NULL, SW_SHOWDEFAULT);
+		#pragma warning(default: 4311 4302) // Allow 4311/4302 again
 		// Access denied happens when the user clicks No/Cancel.
 		if (execResult <= 32 && execResult != SE_ERR_ACCESSDENIED) {
 			result = E_FAIL;

--- a/LegacyUpdate/LaunchUpdateSite.cpp
+++ b/LegacyUpdate/LaunchUpdateSite.cpp
@@ -9,6 +9,10 @@
 
 #pragma comment(lib, "wininet.lib")
 
+// Ignore C4311 and C4302, which is for typecasts. It is due to ShellExec and should be safe to bypass.
+#pragma warning(disable: 4311)
+#pragma warning(disable: 4302)
+
 const LPCSTR UpdateSiteHostname     = "legacyupdate.net";
 const LPWSTR UpdateSiteURLHttp      = L"http://legacyupdate.net/windowsupdate/v6/";
 const LPWSTR UpdateSiteURLHttps     = L"https://legacyupdate.net/windowsupdate/v6/";

--- a/LegacyUpdate/LegacyUpdateCtrl.cpp
+++ b/LegacyUpdate/LegacyUpdateCtrl.cpp
@@ -13,10 +13,6 @@
 #define new DEBUG_NEW
 #endif
 
-// Ignore C4311 and C4302, which is for typecasts. It is due to ShellExec and should be safe to bypass.
-#pragma warning(disable: 4311)
-#pragma warning(disable: 4302)
-
 const BSTR permittedProgIDs[] = {
 	L"Microsoft.Update.",
 	NULL
@@ -297,11 +293,14 @@ STDMETHODIMP CLegacyUpdateCtrl::ViewWindowsUpdateLog(void) {
 
 	// Try Windows Server 2003 Resource Kit (or MSYS/Cygwin/etc) tail.exe, falling back to directly
 	// opening the file (most likely in Notepad).
+	// Ignore C4311 and C4302, which is for typecasts. It is due to ShellExec and should be safe to bypass.
+	#pragma warning(disable: 4311 4302)
 	if ((int)ShellExecute(NULL, L"open", L"tail.exe", L"-f WindowsUpdate.log", windir, SW_SHOWDEFAULT) > 32) {
 		return S_OK;
 	}
 	ShellExecute(NULL, L"open", L"WindowsUpdate.log", NULL, windir, SW_SHOWDEFAULT);
 	return S_OK;
+	#pragma warning(default: 4311 4302) // Allow 4311/4302 again
 }
 
 STDMETHODIMP CLegacyUpdateCtrl::get_IsUsingWsusServer(VARIANT_BOOL *retval) {

--- a/LegacyUpdate/LegacyUpdateCtrl.cpp
+++ b/LegacyUpdate/LegacyUpdateCtrl.cpp
@@ -13,6 +13,10 @@
 #define new DEBUG_NEW
 #endif
 
+// Ignore C4311 and C4302, which is for typecasts. It is due to ShellExec and should be safe to bypass.
+#pragma warning(disable: 4311)
+#pragma warning(disable: 4302)
+
 const BSTR permittedProgIDs[] = {
 	L"Microsoft.Update.",
 	NULL


### PR DESCRIPTION
We'll silence C4311 and C4302, which are about truncations from typecasting.

The calls in question are from ShellExecute, and that function is known to be poorly designed.